### PR TITLE
Correct packages[].tools[].systems.size values for digistump:micronucleus@2.5

### DIFF
--- a/package_digistump_index.json
+++ b/package_digistump_index.json
@@ -389,7 +389,7 @@
               "archiveFileName": "micronucleus-cli-2.5-i686-mingw32.zip",
               "url": "https://github.com/ArminJo/DigistumpArduino/raw/master/tools/micronucleus-cli-2.5-i686-mingw32.zip",
               "checksum": "SHA-256:748b6813a498bb144afbd3169d967c603073f5567cb468db393091c9bea8ff88",
-              "size": "1127648"
+              "size": "1127622"
             },
             {
               "host": "x86_64-apple-darwin14",
@@ -410,7 +410,7 @@
               "archiveFileName": "micronucleus-cli-2.5-x86_64-mingw32.zip",
               "url": "https://github.com/ArminJo/DigistumpArduino/raw/master/tools/micronucleus-cli-2.5-x86_64-mingw32.zip",
               "checksum": "SHA-256:ceb4cbd34863bb0c78c4e32ae3fcfe7e67aac1b2adabfc3ca2da361a34e47a5d",
-              "size": "1133591"
+              "size": "1133565"
             }
           ]
         },


### PR DESCRIPTION
The size values for the` i686-mingw32` and `x86_64-mingw32` hosts were incorrect.

The classic Arduino IDE did not check the `size` value (I seem to remember it was allowed as an alternative for the `checksum` at one point in time). But Arduino CLI, and thus the new Arduino IDE enforce the correct `size` value, which caused installation to fail on the misconfigured host systems:

```
$ arduino-cli core update-index --additional-urls https://raw.githubusercontent.com/ArminJo/DigistumpArduino/master/package_digistump_index.json
...
$ arduino-cli core install digistump:avr --additional-urls https://raw.githubusercontent.com/ArminJo/DigistumpArduino/master/package_digistump_index.json
...
Installing digistump:micronucleus@2.5...
Error during install: installing tool digistump:micronucleus@2.5: testing local archive integrity: testing archive size: fetched archive size differs from size specified in index
```

Temporary Boards Manager URL for testing:
 https://raw.githubusercontent.com/per1234/DigistumpArduino/fix-size/package_digistump_index.json