### PR TITLE
Add AVR compile variables

### DIFF
--- a/digistump-avr/platform.txt
+++ b/digistump-avr/platform.txt
@@ -17,15 +17,21 @@ build.versiondefines=-DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DA
 # AVR compile variables
 # --------------------- 
 
+compiler.warning_flags=-w
+compiler.warning_flags.none=-w
+compiler.warning_flags.default=
+compiler.warning_flags.more=-Wall
+compiler.warning_flags.all=-Wall -Wextra
+
 # Default "compiler.path" is correct, change only if you want to overidde the initial value
 compiler.path={runtime.tools.avr-gcc.path}/bin/
 compiler.c.cmd=avr-gcc
-compiler.c.flags=-c -g -Os -Wall -Wextra -std=gnu11 -ffunction-sections -fdata-sections -flto -MMD
+compiler.c.flags=-c -g -Os {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -flto -MMD
 compiler.c.elf.flags=-Os -g -Wl,--gc-sections -mrelax -fmerge-all-constants
 compiler.c.elf.cmd=avr-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp -flto
 compiler.cpp.cmd=avr-g++
-compiler.cpp.flags=-c -g -Os -Wall -Wextra -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -flto -MMD
+compiler.cpp.flags=-c -g -Os {compiler.warning_flags} -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -flto -MMD
 compiler.ar.cmd=avr-gcc-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=avr-objcopy


### PR DESCRIPTION
This adds the ability to control the output of compiler warnings from the IDE's settings window